### PR TITLE
Add GitHub Action to build and push Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,69 @@
+name: Docker
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  # Run a test build for any PRs.
+  pull_request:
+
+env:
+  IMAGE_NAME: shairport-sync
+
+jobs:
+  # Build the container image for multiple architectures
+  build:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        arch:
+          - linux/386
+          - linux/amd64
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/arm64
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: crazy-max/ghaction-docker-buildx@v1.2.1
+        
+      - name: Build
+        run: |
+          docker buildx build \
+            --platform ${{ matrix.arch }} \
+            --output type=docker,dest=image.tar \
+            .
+
+      - name: Log into registry
+        if: github.event_name == 'push'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        if: github.event_name == 'push'
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker import image.tar $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,15 +20,6 @@ jobs:
   # Build the container image for multiple architectures
   build:
     runs-on: ubuntu-latest
-    
-    strategy:
-      matrix:
-        arch:
-          - linux/386
-          - linux/amd64
-          - linux/arm/v6
-          - linux/arm/v7
-          - linux/arm64
 
     steps:
       - uses: actions/checkout@v2
@@ -37,7 +28,7 @@ jobs:
       - name: Build
         run: |
           docker buildx build \
-            --platform ${{ matrix.arch }} \
+            --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64 \
             --output type=docker,dest=image.tar \
             .
 


### PR DESCRIPTION
This adds a GitHub Actions automation (see #1) to build and push the image automatically.

On incoming pull requests and pushes to branches other than `master`, the image is built for a variety of architectures, but not pushed.

When pushing to `master`, the built image is pushed to `docker.pkg.github.com/rohmilchkaese/shairport-sync/shairport-sync:latest`.

When pushing a tag, it is as above except the tag name is used instead of `latest`.

GitHub's Docker registry currently requires authentication, so it may be preferable to have it push to Docker Hub instead. In this case you would have to configure an [encrypted secret](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) containing the Docker Hub credentials.

Right now I am building each architecture as a separate job to take advantage of parallelism, rather than having a single job that builds multiple architectures. I don't know if the registry properly handles pushing different architectures to the same tag.

The packages show up on pages in the GitHub UI like this one: https://github.com/rgov/shairport-sync/packages/168155