### PR TITLE
Build specific versions of shairport-sync based on tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,7 @@ jobs:
             --platform ${DOCKER_PLATFORMS} \
             --build-arg VERSION=${VERSION} \
             --build-arg ALAC_BRANCH=tags/0.0.7 \
-            --build-arg SHAIRPORT_BRANCH=${SHAIRPORT_BRANCH} \ 
+            --build-arg SHAIRPORT_BRANCH=${SHAIRPORT_BRANCH} \
             --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
             --build-arg VCS_REF=${GITHUB_SHA::8} \
             --tag ${IMAGE_NAME}:${VERSION} \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,11 +41,8 @@ jobs:
           # Output build arguments for downstream steps
           echo ::set-output name=buildx_args::\
             --platform ${DOCKER_PLATFORMS} \
-            --build-arg VERSION=${VERSION} \
             --build-arg ALAC_BRANCH=tags/0.0.7 \
             --build-arg SHAIRPORT_BRANCH=${SHAIRPORT_BRANCH} \
-            --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
-            --build-arg VCS_REF=${GITHUB_SHA::8} \
             --tag ${IMAGE_NAME}:${VERSION} \
             .
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,10 +34,16 @@ jobs:
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
           [ "$VERSION" == "master" ] && VERSION=latest
 
+          # If tagged with a version, build the same version of shairport-sync
+          SHAIRPORT_BRANCH=master
+          [ "$VERSION" != "latest" ] && SHAIRPORT_BRANCH=tags/$VERSION
+
           # Output build arguments for downstream steps
           echo ::set-output name=buildx_args::\
             --platform ${DOCKER_PLATFORMS} \
             --build-arg VERSION=${VERSION} \
+            --build-arg ALAC_BRANCH=tags/0.0.7 \
+            --build-arg SHAIRPORT_BRANCH=${SHAIRPORT_BRANCH} \ 
             --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
             --build-arg VCS_REF=${GITHUB_SHA::8} \
             --tag ${IMAGE_NAME}:${VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:edge
 MAINTAINER 37877524+Rohmilchkaese@users.noreply.github.com
 
-RUN apk -U add \
+RUN env \
+&& apk -U add \
 	git \
 	build-base \
 	autoconf \
@@ -19,7 +20,7 @@ RUN apk -U add \
 && cd /root \
 && git clone "https://github.com/mikebrady/alac.git" \
 && cd /root/alac \
-&& ([ -n "$ALAC_BRANCH" ] && git checkout origin/"$ALAC_BRANCH") \
+&& ([ -n "$ALAC_BRANCH" ] && git checkout origin/"$ALAC_BRANCH" ;:) \
 && autoreconf -fi \
 && ./configure \
 && make \
@@ -27,7 +28,7 @@ RUN apk -U add \
 && cd /root \
 && git clone "https://github.com/mikebrady/shairport-sync.git" \
 && cd /root/shairport-sync \
-&& ([ -n "$SHAIRPORT_BRANCH" ] && git checkout origin/"$SHAIRPORT_BRANCH") \
+&& ([ -n "$SHAIRPORT_BRANCH" ] && git checkout origin/"$SHAIRPORT_BRANCH" ;:) \
 && autoreconf -i -f \
 && ./configure \
 	--with-alsa \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN env \
 && cd /root \
 && git clone "https://github.com/mikebrady/alac.git" \
 && cd /root/alac \
-&& ([ -n "$ALAC_BRANCH" ] && git checkout origin/"$ALAC_BRANCH" ;:) \
+&& ([ -n "$ALAC_BRANCH" ] && git checkout "$ALAC_BRANCH" ;:) \
 && autoreconf -fi \
 && ./configure \
 && make \
@@ -28,7 +28,7 @@ RUN env \
 && cd /root \
 && git clone "https://github.com/mikebrady/shairport-sync.git" \
 && cd /root/shairport-sync \
-&& ([ -n "$SHAIRPORT_BRANCH" ] && git checkout origin/"$SHAIRPORT_BRANCH" ;:) \
+&& ([ -n "$SHAIRPORT_BRANCH" ] && git checkout "$SHAIRPORT_BRANCH" ;:) \
 && autoreconf -i -f \
 && ./configure \
 	--with-alsa \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,19 @@ RUN apk -U add \
 	xmltoman \
 	libconfig-dev \
 	libstdc++ \
-&& cd /root && git clone "https://github.com/mikebrady/alac.git" \
-&& cd /root/alac &&  autoreconf -fi \
+&& cd /root \
+&& git clone "https://github.com/mikebrady/alac.git" \
+&& cd /root/alac \
+&& ([ -n "$ALAC_BRANCH" ] && git checkout origin/"$ALAC_BRANCH") \
+&& autoreconf -fi \
 && ./configure \
 && make \
 && make install \
-&& cd /root && git clone "https://github.com/mikebrady/shairport-sync.git" \
-&& cd /root/shairport-sync && autoreconf -i -f \
+&& cd /root \
+&& git clone "https://github.com/mikebrady/shairport-sync.git" \
+&& cd /root/shairport-sync \
+&& ([ -n "$SHAIRPORT_BRANCH" ] && git checkout origin/"$SHAIRPORT_BRANCH") \
+&& autoreconf -i -f \
 && ./configure \
 	--with-alsa \
         --with-pipe \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM alpine:edge
 MAINTAINER 37877524+Rohmilchkaese@users.noreply.github.com
 
+ARG ALAC_BRANCH=tags/0.0.7
+ARG SHAIRPORT_BRANCH=master
+
 RUN env \
 && apk -U add \
 	git \
@@ -20,7 +23,7 @@ RUN env \
 && cd /root \
 && git clone "https://github.com/mikebrady/alac.git" \
 && cd /root/alac \
-&& ([ -n "$ALAC_BRANCH" ] && git checkout "$ALAC_BRANCH" ;:) \
+&& git checkout "$ALAC_BRANCH" \
 && autoreconf -fi \
 && ./configure \
 && make \
@@ -28,7 +31,7 @@ RUN env \
 && cd /root \
 && git clone "https://github.com/mikebrady/shairport-sync.git" \
 && cd /root/shairport-sync \
-&& ([ -n "$SHAIRPORT_BRANCH" ] && git checkout "$SHAIRPORT_BRANCH" ;:) \
+&& git checkout "$SHAIRPORT_BRANCH" \
 && autoreconf -i -f \
 && ./configure \
 	--with-alsa \

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# shairport-sync
-shairport-sync docker image - including Apple Alac decoder - based on Alpine Linux 
+![Docker](https://github.com/rohmilchkaese/shairport-sync/workflows/Docker/badge.svg)
 
-Link to [Docker Hub](https://hub.docker.com/r/rohmilkaese/shairport-sync)
+# Shairport Sync as a Docker Image
 
-Supported architectures ready to download via Docker Hub: 
-linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64, linux/ppc64le, linux/s390x 
+[Shairport Sync](https://github.com/mikebrady/shairport-sync) is an Apple AirPlay receiver. It can receive audio directly from iOS devices, iTunes, etc. Multiple instances of Shairport Sync will stay in sync with each other and other AirPlay devices when used with a compatible multi-room player, such as iTunes or [forked-daapd](https://github.com/jasonmc/forked-daapd).
 
-[shairport-sync](https://github.com/mikebrady/shairport-sync) is an Apple AirPlay receiver. It can receive audio directly from iOS devices, iTunes, etc. Multiple instances of shairport-sync will stay in sync with each other and other AirPlay devices when used with a compatible multi-room player, such as iTunes or [forked-daapd](https://github.com/jasonmc/forked-daapd).
+This Docker image provides an easy way to deploy Shairport Sync. Based on Alpine Linux, the image is very small and it is built for multiple platforms, making it suitable for embedded devices such as Raspberry Pi. Support for the Apple Lossless Audio Codec (ALAC) is included.
+
+[See available images on Docker Hub.](https://hub.docker.com/r/rohmilkaese/shairport-sync)
 
 This is a fork of the project by [Kevin Eye](https://github.com/kevineye/docker-shairport-sync).
+
 
 ## Docker Run
 
@@ -16,12 +17,12 @@ Command:
 
 ```bash
 sudo docker run -d \
--v $PWD:/conf/ \
---net host \
---device /dev/snd \
---name shairport-sync \
-rohmilkaese/shairport-sync \
--vu -c /conf/shairport.conf
+    -v $PWD:/conf/ \
+    --net host \
+    --device /dev/snd \
+    --name shairport-sync \
+    rohmilkaese/shairport-sync \
+    -vu -c /conf/shairport.conf
 ```
 Place a valid shairport.conf file in directory you run the docker run command.
 


### PR DESCRIPTION
This change to the build makes it so that when you create a tag like `v3.3.6`, it will build and push the corresponding tag of shairport-sync (`3.3.6`). In other words, to make a new release, just make a new tag, and the rest is automated.

I've also updated the README.