### PR TITLE
Update Docker base image and dependencies, upgrade GitHub Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,24 +22,24 @@ jobs:
     steps:
       # Get the repository's code
       - name: Checkout
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v6
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1.2.0
+        uses: docker/setup-qemu-action@v3
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1.6.0
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           
       - name: Docker meta
         id: shairport-sync # you'll use this in the next step
-        uses: docker/metadata-action@v3.7.0
+        uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -56,7 +56,7 @@ jobs:
           #  type=sha
       
       - name: Build and push
-        uses: docker/build-push-action@v2.10.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/arm/v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.20.1
+FROM alpine:3.21
 ARG ALAC_BRANCH=tags/0.0.7
-ARG SHAIRPORT_BRANCH=4.3.4
+ARG SHAIRPORT_BRANCH=4.3.7
 
 RUN env \
 && apk -U add \
@@ -12,7 +12,7 @@ RUN env \
 	alsa-lib-dev \
 	libdaemon-dev \
 	popt-dev \
-	libressl-dev \
+	openssl-dev \
 	soxr-dev \
 	avahi-dev \
 	xmltoman \
@@ -52,7 +52,7 @@ RUN env \
         alsa-lib-dev \
         libdaemon-dev \
         popt-dev \
-        libressl-dev \
+        openssl-dev \
         soxr-dev \
         avahi-dev \
         libconfig-dev \
@@ -64,12 +64,11 @@ RUN env \
         alsa-lib \
         libdaemon \
         popt \
-        libressl \
+        libssl3 \
         soxr \
         avahi \
         libconfig \
         libstdc++ \
-        libressl3.8-libssl \
 && rm -rf \
         /etc/ssl \
         /var/cache/apk/* \


### PR DESCRIPTION
## Summary
This PR updates the Docker configuration to use newer versions of the base image and dependencies, while also upgrading all GitHub Actions to their latest versions for improved security and performance.

## Key Changes

### Docker Base Image & Dependencies
- **Alpine Linux**: Updated from 3.20.1 to 3.21
- **Shairport Sync**: Updated from version 4.3.4 to 4.3.7
- **SSL Library**: Migrated from `libressl-dev` to `openssl-dev` (build dependencies)
- **Runtime Libraries**: 
  - Replaced `libressl` with `libssl3`
  - Removed `libressl3.8-libssl` (now handled by libssl3)

### GitHub Actions Upgrades
- `actions/checkout`: v3.0.1 → v6
- `docker/setup-qemu-action`: v1.2.0 → v3
- `docker/setup-buildx-action`: v1.6.0 → v3
- `docker/login-action`: v1.14.1 → v3
- `docker/metadata-action`: v3.7.0 → v5
- `docker/build-push-action`: v2.10.0 → v6

## Notable Details
- The migration from LibreSSL to OpenSSL aligns with Alpine Linux 3.21's default SSL provider
- Consolidated SSL runtime dependencies for a cleaner final image
- All GitHub Actions are now on major versions that receive active maintenance and security updates

https://claude.ai/code/session_01ABc14E7yBAAQ3aeqUhmRpE